### PR TITLE
25 Improve docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ docs/mdbook
 hs_err*.log
 /data/
 /metrics/
+docker/**/*.jar

--- a/README.md
+++ b/README.md
@@ -12,14 +12,32 @@ This is a monitoring application for [Zeebe](https://zeebe.io). It has two parts
 * inspect workflow instances, including payload and incidents
 * management operations (e.g. new deployment, cancel workflow instance, update payload)
 
+## How to run
 
-## How to build
+### With Docker
+
+The following command will build the project, pull images and start containers with default settings.
+
+In your terminal (in the root project folder):
+
+```bash
+docker/run
+```
+Note: You can build the project with maven in a containerized environ by commenting the line 14 and uncommenting the line 15 in the `docker/run` file.
+If you don't have the right to launch `docker/run` try : 
+
+```bash
+chmod +x docker/run
+```
+and try again.
+
+### Manually
+
+#### How to build
 
 Build with Maven
 
 `mvn clean install`
-
-## How to run
 
 Before you start the broker, copy the exporter JAR from the target folder into the lib folder of the broker.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,19 @@
+# Usage
+
+The following command will build the project, pull images and start containers with default settings.
+
+In your terminal:
+
+```bash
+docker/run
+```
+
+If you don't have the right to launch `docker/run` run 
+
+```bash
+chmod +x docker/run
+```
+and try again.
+
+
+Go to http://localhost:9000 and connect to broker `zeebe:26500`.

--- a/docker/local-config/docker-compose.yml
+++ b/docker/local-config/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '2'
+
+services:
+  db:
+    image: oscarfonts/h2
+    container_name: zeebe_db
+    ports:
+      - "1521:1521"
+      - "81:81"
+    networks:
+        - zeebe-network
+  zeebe:
+    container_name: zeebe_broker
+    image: camunda/zeebe:latest
+    environment:
+        - ZEEBE_LOG_LEVEL=debug
+    ports:
+      - "26500:26500"
+    volumes:
+      - ./zeebe-simple-monitor-exporter.jar:/usr/local/zeebe/lib/zeebe-simple-monitor-exporter.jar
+      - ./zeebe.cfg.toml:/usr/local/zeebe/conf/zeebe.cfg.toml 
+    networks:
+        - zeebe-network
+    depends_on:
+        - db
+  monitor:
+    container_name: zeebe_monitor
+    image: camunda/zeebe-simple-monitor:latest
+    environment:
+      - spring.datasource.url=jdbc:h2:tcp://db:1521/zeebe-monitor
+    ports:
+      - "8080:8080"
+    depends_on:
+        - db
+    networks:
+        - zeebe-network
+networks:
+    zeebe-network:
+      driver: bridge

--- a/docker/local-config/zeebe.cfg.toml
+++ b/docker/local-config/zeebe.cfg.toml
@@ -1,0 +1,338 @@
+# Zeebe broker configuration file
+
+# Overview -------------------------------------------
+
+# This file contains a complete list of available configuration options.
+
+# Default values:
+#
+# When the default value is used for a configuration option, the option is
+# commented out. You can learn the default value from this file
+
+# Conventions:
+#
+# Byte sizes
+# For buffers and others must be specified as strings and follow the following
+# format: "10U" where U (unit) must be replaced with K = Kilobytes, M = Megabytes or G = Gigabytes.
+# If unit is omitted then the default unit is simply bytes.
+# Example:
+# sendBufferSize = "16M" (creates a buffer of 16 Megabytes)
+#
+# Time units
+# Timeouts, intervals, and the likes, must be specified as strings and follow the following
+# format: "VU", where:
+#   - V is a numerical value (e.g. 1, 1.2, 3.56, etc.)
+#   - U is the unit, one of: ms = Millis, s = Seconds, m = Minutes, or h = Hours
+#
+# Paths:
+# Relative paths are resolved relative to the installation directory of the
+# broker.
+
+# ----------------------------------------------------
+
+[network]
+
+# This section contains the network configuration. Particularly, it allows to
+# configure the hosts and ports the broker should bind to. the broker exposes 3
+# ports: 1. client: the port on which client (Java, CLI, Go, ...) connections
+# are handled 2. management: used internally by the cluster for the gossip
+# membership protocol and other management interactions 3. replication: used
+# internally by the cluster for replicating data across nodes using the raft
+# protocol
+
+# Controls the default host the broker should bind to. Can be overwritten on a
+# per binding basis for client, management and replication
+#
+# This setting can also be overridden using the environment variable ZEEBE_HOST.
+# host = "0.0.0.0"
+
+# If a port offset is set it will be added to all ports specified in the config
+# or the default values. This is a shortcut to not always specifying every port.
+#
+# The offset will be added to the second last position of the port, as Zeebe
+# requires multiple ports. As example a portOffset of 5 will increment all ports
+# by 50, i.e. 26500 will become 26550 and so on.
+#
+# This setting can also be overridden using the environment variable ZEEBE_PORT_OFFSET.
+# portOffset = 0
+
+# Controls the default size of the buffers that are used for buffering outgoing
+# messages. Can be overwritten on a per binding basis for client, management and
+# replication
+# defaultSendBufferSize = "16M"
+
+[network.gateway]
+
+# Enables embedded gateway to start
+# enabled = true
+#
+# Overrides the host the gateway binds to
+# host = "localhost"
+#
+# Sets the port the gateway binds to
+# port = 26500
+
+[network.client]
+
+# Allows to override the host the client api binds to
+# host = "localhost"
+#
+# The port the client api binds to
+# port = 26501
+#
+# Overrides the size of the buffer used for buffering outgoing messages to
+# clients
+# sendBufferSize = "16M"
+#
+# Sets the size of the buffer used for receiving control messages from clients
+# (such as management of subscriptions)
+# controlMessageBufferSize = "8M"
+
+[network.management]
+
+# Overrides the host the management api binds to
+# host = "localhost"
+#
+# Sets the port the management api binds to
+# port = 26502
+#
+# Overrides the size of the buffer to be used for buffering outgoing messages to
+# other brokers through the management protocols
+# sendBufferSize = "16M"
+#
+# Sets the buffer size used for receiving gossip messages and others
+# receiveBufferSize = "8M"
+
+[network.replication]
+
+# Overrides the host the replication api binds to
+# host = "localhost"
+#
+# Sets the port the replication api binds to
+# port = 26503
+#
+# Sets the buffer size used for buffering outgoing raft (replication) messages
+# sendBufferSize = "16M"
+
+[network.subscription]
+
+# Overrides the host the subscription api binds to
+# host = "localhost"
+#
+# Sets the port the subscription api binds to
+# port = 26504
+#
+# Overrides the size of the buffer to be used for buffering outgoing messages to
+# other brokers through the subscription protocols
+# sendBufferSize = "16M"
+#
+# Sets the buffer size used for receiving subscription messages and others
+# receiveBufferSize = "8M"
+
+
+[data]
+
+# This section allows to configure Zeebe's data storage. Data is stored in
+# "partition folders". A partition folder has the following structure:
+#
+# internal-system-0                 (root partition folder)
+# ├── partition.json                (metadata about the partition)
+# ├── segments                      (the actual data as segment files)
+# │   ├── 00.data
+# │   └── 01.data
+# └── snapshots                     (snapshot data)
+#
+
+# Specify a list of directories in which data is stored. Using multiple
+# directories makes sense in case the machine which is running Zeebe has
+# multiple disks which are used in a JBOD (just a bunch of disks) manner. This
+# allows to get greater throughput in combination with a higher io thread count
+# since writes to different disks can potentially be done in parallel.
+#
+# This setting can also be overridden using the environment variable ZEEBE_DIRECTORIES.
+# directories = [ "data" ]
+
+# The default size of data segments.
+# defaultSegmentSize = "512M"
+
+# How often we take snapshots of streams (time unit)
+# snapshotPeriod = "15m"
+
+# How often follower partitions will check for new snapshots to replicate from
+# the leader partitions. Snapshot replication enables faster failover by
+# reducing how many log entries must be reprocessed in case of leader change.
+# snapshotReplicationPeriod = "5m"
+
+
+[cluster]
+
+# This section contains all cluster related configurations, to setup an zeebe cluster
+
+# Specifies the unique id of this broker node in a cluster.
+# The id should be between 0 and number of nodes in the cluster (exclusive).
+#
+# This setting can also be overridden using the environment variable ZEEBE_NODE_ID.
+# nodeId = 0
+
+# Controls the number of partitions, which should exist in the cluster.
+#
+# This can also be overridden using the environment variable ZEEBE_PARTITIONS_COUNT.
+# partitionsCount = 1
+
+# Controls the replication factor, which defines the count of replicas per partition.
+# The replication factor cannot be greater than the number of nodes in the cluster.
+#
+# This can also be overridden using the environment variable ZEEBE_REPLICATION_FACTOR.
+# replicationFactor = 1
+
+# Specifies the zeebe cluster size. This value is used to determine which broker
+# is responsible for which partition.
+#
+# This can also be overridden using the environment variable ZEEBE_CLUSTER_SIZE.
+# clusterSize = 1
+
+# Allows to specify a list of known other nodes to connect to on startup
+# The contact points of the management api must be specified.
+# The format is [HOST:PORT]
+# Example:
+# initialContactPoints = [ "192.168.1.22:26502", "192.168.1.32:26502" ]
+#
+# This setting can also be overridden using the environment variable ZEEBE_CONTACT_POINTS
+# specifying a comma-separated list of contact points.
+#
+# Default is empty list:
+# initialContactPoints = []
+
+[threads]
+
+# Controls the number of non-blocking CPU threads to be used. WARNING: You
+# should never specify a value that is larger than the number of physical cores
+# available. Good practice is to leave 1-2 cores for ioThreads and the operating
+# system (it has to run somewhere). For example, when running Zeebe on a machine
+# which has 4 cores, a good value would be 2.
+#
+# The default value is 2.
+#cpuThreadCount = 2
+
+# Controls the number of io threads to be used. These threads are used for
+# workloads that write data to disk. While writing, these threads are blocked
+# which means that they yield the CPU.
+#
+# The default value is 2.
+#ioThreadCount = 2
+
+[metrics]
+
+# Path to the file to which metrics are written. Metrics are written in a
+# text-based format understood by prometheus.io
+# metricsFile = "metrics/zeebe.prom"
+
+# Controls the interval at which the metrics are written to the metrics file
+# reportingInterval = "5s"
+
+[gossip]
+
+# retransmissionMultiplier = 3
+# probeInterval = "1s"
+# probeTimeout = "500ms"
+# probeIndirectNodes = 3
+# probeIndirectTimeout = "1s"
+# suspicionMultiplier = 5
+# syncTimeout = "3s"
+# syncInterval = "15s"
+# joinTimeout = "1s"
+# joinInterval = "5s"
+# leaveTimeout = "1s"
+# maxMembershipEventsPerMessage = 32
+# maxCustomEventsPerMessage = 8
+
+[raft]
+
+# heartbeatInterval = "250ms"
+# electionInterval = "1s"
+# leaveTimeout = "1s"
+
+# Configure exporters below; note that configuration parsing conventions do not apply to exporter
+# arguments, which will be parsed as normal TOML.
+#
+# Each exporter should be configured following this template:
+#
+# id:
+#   property should be unique in this configuration file, as it will server as the exporter
+#   ID for loading/unloading.
+# jarPath:
+#   path to the JAR file containing the exporter class. JARs are only loaded once, so you can define
+#   two exporters that point to the same JAR, with the same class or a different one, and use args
+#   to parametrize its instantiation.
+# className:
+#   entry point of the exporter, a class which *must* extend the io.zeebe.exporter.Exporter
+#   interface.
+#
+# A nested table as [exporters.args] will allow you to inject arbitrary arguments into your
+# class through the use of annotations.
+#
+# Enable the following exporter to get debug output of the exporter records
+#
+# [[exporters]]
+# id = "debug"
+# className = "io.zeebe.broker.exporter.DebugExporter"
+# [exporters.args]
+#   logLevel = "debug"
+#   prettyPrint = false
+#
+# An example configuration for the elasticsearch exporter:
+#
+[[exporters]]
+id = "simple-monitor"
+className = "io.zeebe.monitor.SimpleMonitorExporter"
+
+[exporters.args]
+  jdbcUrl = "jdbc:h2:tcp://db:1521/zeebe-monitor"
+
+  # The driver name of the jdbc driver implementation. Make sure that the implementation is
+  # available in the exporter/broker classpath (add it to the broker lib folder).
+  # The name is used to load the driver implementation like this
+  # Class.forName(configuration.driverName);
+  # 
+  driverName = "org.h2.Driver"
+  userName = "sa"
+  password = ""
+
+  # To configure the amount of records, which has to be reached before the records are exported to
+  # the database. Only counts the records which are in the end actually exported.
+  #
+  # batchSize = 100;
+
+  # To configure the time in milliseconds, when the batch should be executed regardless whether the
+  # batch size was reached or not.
+  #
+  #If the value is less then one, then no timer will be scheduled.
+  #
+  #batchTimerMilli = 1000
+
+#id = "elasticsearch"
+#className = "io.zeebe.exporter.ElasticsearchExporter"
+#
+#  [exporters.args]
+#  url = "http://localhost:9200"
+#
+#  [exporters.args.bulk]
+#  delay = 5
+#  size = 1_000
+#
+#  [exporters.args.index]
+#  prefix = "zeebe-record"
+#  createTemplate = true
+#
+#  command = false
+#  event = true
+#  rejection = false
+#
+#  deployment = true
+#  incident = true
+#  job = true
+#  message = false
+#  messageSubscription = false
+#  raft = false
+#  workflowInstance = true
+#  workflowInstanceSubscription = false

--- a/docker/run
+++ b/docker/run
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+CONFIG_FILE=docker/local-config/docker-compose.yml
+PULL_CMD="docker-compose -f $CONFIG_FILE pull"
+UP_CMD="docker-compose up"
+
+function rmContainers() {
+  docker-compose -f $CONFIG_FILE rm -fv $SERVICE_NAME || true
+}
+
+echo "Building project"
+mvn clean install
+# docker run -it --rm --name maven-zeebe-simple-monitor -v "$(pwd)":/usr/src/zeebe-simple-monitor -w /usr/src/zeebe-simple-monitor maven:3.3-jdk-8 mvn clean install
+echo "Done"
+
+CONTAINERS=(zeebe_monitor zeebe_broker zeebe_db)
+
+for i in "${!CONTAINERS[@]}"
+do
+   SERVICE_NAME=${CONTAINERS[$i]} rmContainers
+done
+
+$PULL_CMD
+
+echo "copying jar"
+cp exporter/target/zeebe-simple-monitor-exporter-*.jar docker/local-config/zeebe-simple-monitor-exporter.jar
+echo "Done"
+
+cd docker/local-config/
+echo "starting containers"
+$UP_CMD
+
+cd ../..


### PR DESCRIPTION
See https://github.com/zeebe-io/zeebe-simple-monitor/issues/25#issuecomment-437475081

Add docker folder in order to have other subfolders if needed
Add new docker-compose for running zeebe broker with zeebe-simple-monitor
Add bash script in order to automate every steps
Update README in order to explain "How to run" with docker

Please let me know if I can improve anything else!