### PR TITLE
Environmentalise broker connection in docker-compose

### DIFF
--- a/docker/local-config/docker-compose.yml
+++ b/docker/local-config/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     image: camunda/zeebe-simple-monitor:latest
     environment:
       - spring.datasource.url=jdbc:h2:tcp://db:1521/zeebe-monitor
+      - io.zeebe.monitor.connectionString=zeebe:26500
     ports:
       - "8080:8080"
     depends_on:


### PR DESCRIPTION
fixes #48 

This adds `io.zeebe.monitor.connectionString=zeebe:26500` to the environment of docker-compose to allow the Simple Monitor to communicate with the broker.