### PR TITLE
Bugfix for Issue #59 Docker compose fails with 0.15.0

### DIFF
--- a/docker/run
+++ b/docker/run
@@ -15,7 +15,7 @@ mvn clean install
 # docker run -it --rm --name maven-zeebe-simple-monitor -v "$(pwd)":/usr/src/zeebe-simple-monitor -w /usr/src/zeebe-simple-monitor maven:3.3-jdk-8 mvn clean install
 echo "Done"
 
-CONTAINERS=(zeebe_monitor zeebe_broker zeebe_db)
+CONTAINERS=(monitor zeebe db)
 
 for i in "${!CONTAINERS[@]}"
 do


### PR DESCRIPTION
The docker run script could not remove the containers as it was meant in the script. This was causing problems because of the database schema changes.