### PR TITLE
Update url in docker/readme

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -16,4 +16,4 @@ chmod +x docker/run
 and try again.
 
 
-Go to http://localhost:9000 and connect to broker `zeebe:26500`.
+Open a web browser and go to http://localhost:8080


### PR DESCRIPTION
The url in this readme was wrong
Remove "connect to broker zeebe:26500" because it's not needed.