### PR TITLE
Correct grammar of workflow instance change notifications

### DIFF
--- a/app/src/main/resources/public/js/app.js
+++ b/app/src/main/resources/public/js/app.js
@@ -64,7 +64,7 @@ function reload() {
                 }
 
                 if (subscribedWorkflowKeys.includes(notification.workflowKey)) {
-                    showInfo('An instances of the workflow has changed.');
+                    showInfo('Instance(s) of this workflow have changed.');
                 }
             }
 						


### PR DESCRIPTION
The current grammar is not quite right. Alternatively this could be worded as:

"An instance of this workflow has changed."