### PR TITLE
Add last page link in paginated tables

### DIFF
--- a/src/main/java/io/zeebe/monitor/rest/ViewController.java
+++ b/src/main/java/io/zeebe/monitor/rest/ViewController.java
@@ -804,14 +804,22 @@ public class ViewController {
   private void addPaginationToModel(
       Map<String, Object> model, Pageable pageable, final long count) {
 
-    final int currentPage = pageable.getPageNumber();
-    model.put("page", currentPage + 1);
-    if (currentPage > 0) {
-      model.put("prevPage", currentPage - 1);
-    }
-    if (count > (1 + currentPage) * pageable.getPageSize()) {
-      model.put("nextPage", currentPage + 1);
-    }
+      final int currentPage = pageable.getPageNumber();
+      model.put("page", currentPage + 1);
+      if (currentPage > 0) {
+          model.put("prevPage", currentPage - 1);
+      }
+      if (count > (1 + currentPage) * pageable.getPageSize()) {
+          model.put("nextPage", currentPage + 1);
+      }
+
+      if(pageable.getPageSize() > 0) {
+          long lastPage = count / pageable.getPageSize();
+          if(count % pageable.getPageSize() == 0) {
+              lastPage--;
+          }
+          model.put("lastPage", lastPage);
+      }
   }
 
     private void addContextPathToModel(Map<String, Object> model) {

--- a/src/main/resources/templates/components/table-pagination.html
+++ b/src/main/resources/templates/components/table-pagination.html
@@ -25,5 +25,16 @@
 	      <a class="page-link" href="#" tabindex="-1">Next</a>
 	    </li>
   	{{/nextPage}}
+	{{#lastPage}}
+	    <li class="page-item">
+		  <a class="page-link" href="?page={{lastPage}}" tabindex="-1">Last</a>
+	    </li>
+	{{/lastPage}}
+	{{^lastPage}}
+	    <li class="page-item disabled">
+		  <a class="page-link" href="#" tabindex="-1">Last</a>
+	    </li>
+	{{/lastPage}}
+
   </ul>
 </nav>


### PR DESCRIPTION
When working on workflows that have many instances the most recent one that ususally is of interest can be many pages ahead. People have to click multiple times to get to the last page or do math and manipulate manually the pageNumber in the url parameters neither of which are ideal.